### PR TITLE
Add parse_ulid_timestamp() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A ULID however:
 
 ```sql
 SELECT generate_ulid(); -- Output: 01D45VGTV648329YZFE7HYVGWC
+SELECT parse_ulid_timestamp('01D45VGTV648329YZFE7HYVGWC'); -- Output: 2019-02-20 16:23:49.35+00
 ```
 
 ## Specification


### PR DESCRIPTION
Extracts the timestamp from a generated ULID

eg:
```sql
postgres=# select now(), parse_ulid_timestamp(generate_ulid());
              now              |     parse_ulid_timestamp
-------------------------------+----------------------------
 2020-01-08 14:04:43.441019+00 | 2020-01-08 14:04:43.441+00
(1 row)
```