### PR TITLE
Use CLOCK_TIMESTAMP instead of NOW

### DIFF
--- a/pgulid.sql
+++ b/pgulid.sql
@@ -31,7 +31,7 @@ DECLARE
   ulid       BYTEA;
 BEGIN
   -- 6 timestamp bytes
-  unix_time = (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+  unix_time = (EXTRACT(EPOCH FROM CLOCK_TIMESTAMP()) * 1000)::BIGINT;
   timestamp = SET_BYTE(timestamp, 0, (unix_time >> 40)::BIT(8)::INTEGER);
   timestamp = SET_BYTE(timestamp, 1, (unix_time >> 32)::BIT(8)::INTEGER);
   timestamp = SET_BYTE(timestamp, 2, (unix_time >> 24)::BIT(8)::INTEGER);


### PR DESCRIPTION
When generating ULIDs inside a transaction, the timestamp of every ULID will be the same because the value of `NOW` is only computed when the transaction begins. This effectively reduces the precision of the ID.

`CLOCK_TIMESTAMP` is resolved when the statement is executed, so each ULID created in a transaction will contain a more accurate timestamp.